### PR TITLE
Trusted relay

### DIFF
--- a/contracts/DelegatableRelay.sol
+++ b/contracts/DelegatableRelay.sol
@@ -1,0 +1,146 @@
+// SPDe-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// import "hardhat/console.sol";
+import {EIP712DOMAIN_TYPEHASH} from "./TypesAndDecoders.sol";
+import {Delegation, Invocation, Invocations, SignedInvocation, SignedDelegation} from "./CaveatEnforcer.sol";
+import {DelegatableCore} from "./DelegatableCore.sol";
+import {IDelegatable} from "./interfaces/IDelegatable.sol";
+
+abstract contract DelegatableRelay is IDelegatable, DelegatableCore {
+    /// @notice The hash of the domain separator used in the EIP712 domain hash.
+    bytes32 public immutable domainHash;
+
+    /**
+     * @notice Delegatable Constructor
+     * @param contractName string - The name of the contract
+     * @param version string - The version of the contract
+     */
+    constructor(string memory contractName, string memory version) {
+        domainHash = getEIP712DomainHash(
+            contractName,
+            version,
+            block.chainid,
+            address(this)
+        );
+    }
+
+    /* ===================================================================================== */
+    /* External Functions                                                                    */
+    /* ===================================================================================== */
+
+    /// @inheritdoc IDelegatable
+    function getDelegationTypedDataHash(Delegation memory delegation)
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainHash,
+                GET_DELEGATION_PACKETHASH(delegation)
+            )
+        );
+        return digest;
+    }
+
+    /// @inheritdoc IDelegatable
+    function getInvocationsTypedDataHash(Invocations memory invocations)
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainHash,
+                GET_INVOCATIONS_PACKETHASH(invocations)
+            )
+        );
+        return digest;
+    }
+
+    function getEIP712DomainHash(
+        string memory contractName,
+        string memory version,
+        uint256 chainId,
+        address verifyingContract
+    ) public pure returns (bytes32) {
+        bytes memory encoded = abi.encode(
+            EIP712DOMAIN_TYPEHASH,
+            keccak256(bytes(contractName)),
+            keccak256(bytes(version)),
+            chainId,
+            verifyingContract
+        );
+        return keccak256(encoded);
+    }
+
+    function verifyDelegationSignature(SignedDelegation memory signedDelegation)
+        public
+        view
+        virtual
+        override(IDelegatable, DelegatableCore)
+        returns (address)
+    {
+        Delegation memory delegation = signedDelegation.delegation;
+        bytes32 sigHash = getDelegationTypedDataHash(delegation);
+        address recoveredSignatureSigner = recover(
+            sigHash,
+            signedDelegation.signature
+        );
+        return recoveredSignatureSigner;
+    }
+
+    function verifyInvocationSignature(SignedInvocation memory signedInvocation)
+        public
+        view
+        returns (address)
+    {
+        bytes32 sigHash = getInvocationsTypedDataHash(
+            signedInvocation.invocations
+        );
+        address recoveredSignatureSigner = recover(
+            sigHash,
+            signedInvocation.signature
+        );
+        return recoveredSignatureSigner;
+    }
+
+    // --------------------------------------
+    // WRITES
+    // --------------------------------------
+
+    /// @inheritdoc IDelegatable
+    function contractInvoke(Invocation[] calldata batch)
+        external
+        override
+        returns (bool)
+    {
+        return _invoke(batch, msg.sender);
+    }
+
+    /// @inheritdoc IDelegatable
+    function invoke(SignedInvocation[] calldata signedInvocations)
+        external
+        override
+        returns (bool success)
+    {
+        for (uint256 i = 0; i < signedInvocations.length; i++) {
+            SignedInvocation calldata signedInvocation = signedInvocations[i];
+            address invocationSigner = verifyInvocationSignature(
+                signedInvocation
+            );
+            _enforceReplayProtection(
+                invocationSigner,
+                signedInvocations[i].invocations.replayProtection
+            );
+            _invoke(signedInvocation.invocations.batch, invocationSigner);
+        }
+    }
+
+    /* ===================================================================================== */
+    /* Internal Functions                                                                    */
+    /* ===================================================================================== */
+}

--- a/contracts/DelegatableRelay.sol
+++ b/contracts/DelegatableRelay.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.15;
 // import "hardhat/console.sol";
 import {EIP712DOMAIN_TYPEHASH} from "./TypesAndDecoders.sol";
 import {Delegation, Invocation, Invocations, SignedInvocation, SignedDelegation} from "./CaveatEnforcer.sol";
-import {DelegatableCore} from "./DelegatableCore.sol";
+import {DelegatableRelayCore} from "./DelegatableRelayCore.sol";
 import {IDelegatable} from "./interfaces/IDelegatable.sol";
 
-abstract contract DelegatableRelay is IDelegatable, DelegatableCore {
+abstract contract DelegatableRelay is IDelegatable, DelegatableRelayCore {
     /// @notice The hash of the domain separator used in the EIP712 domain hash.
     bytes32 public immutable domainHash;
 
@@ -81,7 +81,7 @@ abstract contract DelegatableRelay is IDelegatable, DelegatableCore {
         public
         view
         virtual
-        override(IDelegatable, DelegatableCore)
+        override(IDelegatable, DelegatableRelayCore)
         returns (address)
     {
         Delegation memory delegation = signedDelegation.delegation;

--- a/contracts/DelegatableRelay.sol
+++ b/contracts/DelegatableRelay.sol
@@ -7,19 +7,17 @@ import {Delegation, Invocation, Invocations, SignedInvocation, SignedDelegation}
 import {DelegatableRelayCore} from "./DelegatableRelayCore.sol";
 import {IDelegatable} from "./interfaces/IDelegatable.sol";
 
-abstract contract DelegatableRelay is IDelegatable, DelegatableRelayCore {
+contract DelegatableRelay is IDelegatable, DelegatableRelayCore {
     /// @notice The hash of the domain separator used in the EIP712 domain hash.
     bytes32 public immutable domainHash;
 
     /**
-     * @notice Delegatable Constructor
-     * @param contractName string - The name of the contract
-     * @param version string - The version of the contract
+     * @notice Delegatable Relay Constructor
      */
-    constructor(string memory contractName, string memory version) {
+    constructor() {
         domainHash = getEIP712DomainHash(
-            contractName,
-            version,
+            'DelegatableRelay',
+            '1',
             block.chainid,
             address(this)
         );

--- a/contracts/DelegatableRelayCore.sol
+++ b/contracts/DelegatableRelayCore.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {EIP712Decoder, EIP712DOMAIN_TYPEHASH} from "./TypesAndDecoders.sol";
+import {Delegation, Invocation, Invocations, SignedInvocation, SignedDelegation, Transaction, ReplayProtection, CaveatEnforcer} from "./CaveatEnforcer.sol";
+
+abstract contract DelegatableCore is EIP712Decoder {
+    /// @notice Account delegation nonce manager
+    mapping(address => mapping(uint256 => uint256)) internal multiNonce;
+
+    function getNonce(address intendedSender, uint256 queue)
+        external
+        view
+        returns (uint256)
+    {
+        return multiNonce[intendedSender][queue];
+    }
+
+    function verifyDelegationSignature(SignedDelegation memory signedDelegation)
+        public
+        view
+        virtual
+        returns (address);
+
+    function _enforceReplayProtection(
+        address intendedSender,
+        ReplayProtection memory protection
+    ) internal {
+        uint256 queue = protection.queue;
+        uint256 nonce = protection.nonce;
+        require(
+            nonce == (multiNonce[intendedSender][queue] + 1),
+            "DelegatableCore:nonce2-out-of-order"
+        );
+        multiNonce[intendedSender][queue] = nonce;
+    }
+
+    function _execute(
+        address to,
+        bytes memory data,
+        uint256 gasLimit,
+        address sender
+    ) internal returns (bool success) {
+        bytes memory full = abi.encodePacked(data, sender);
+        assembly {
+            success := call(gasLimit, to, 0, add(full, 0x20), mload(full), 0, 0)
+        }
+    }
+
+    function _invoke(Invocation[] calldata batch, address sender)
+        internal
+        returns (bool success)
+    {
+        for (uint256 x = 0; x < batch.length; x++) {
+            Invocation memory invocation = batch[x];
+            address intendedSender;
+            address canGrant;
+
+            // If there are no delegations, this invocation comes from the signer
+            if (invocation.authority.length == 0) {
+                intendedSender = sender;
+                canGrant = intendedSender;
+            }
+
+            bytes32 authHash = 0x0;
+
+            for (uint256 d = 0; d < invocation.authority.length; d++) {
+                SignedDelegation memory signedDelegation = invocation.authority[
+                    d
+                ];
+                address delegationSigner = verifyDelegationSignature(
+                    signedDelegation
+                );
+
+                // Implied sending account is the signer of the first delegation
+                if (d == 0) {
+                    intendedSender = delegationSigner;
+                    canGrant = intendedSender;
+                }
+
+                require(
+                    delegationSigner == canGrant,
+                    "DelegatableCore:invalid-delegation-signer"
+                );
+
+                Delegation memory delegation = signedDelegation.delegation;
+                require(
+                    delegation.authority == authHash,
+                    "DelegatableCore:invalid-authority-delegation-link"
+                );
+
+                // TODO: maybe delegations should have replay protection, at least a nonce (non order dependent),
+                // otherwise once it's revoked, you can't give the exact same permission again.
+                bytes32 delegationHash = GET_SIGNEDDELEGATION_PACKETHASH(
+                    signedDelegation
+                );
+
+                // Each delegation can include any number of caveats.
+                // A caveat is any condition that may reject a proposed transaction.
+                // The caveats specify an external contract that is passed the proposed tx,
+                // As well as some extra terms that are used to parameterize the enforcer.
+                for (uint16 y = 0; y < delegation.caveats.length; y++) {
+                    CaveatEnforcer enforcer = CaveatEnforcer(
+                        delegation.caveats[y].enforcer
+                    );
+                    bool caveatSuccess = enforcer.enforceCaveat(
+                        delegation.caveats[y].terms,
+                        invocation.transaction,
+                        delegationHash
+                    );
+                    require(caveatSuccess, "DelegatableCore:caveat-rejected");
+                }
+
+                // Store the hash of this delegation in `authHash`
+                // That way the next delegation can be verified against it.
+                authHash = delegationHash;
+                canGrant = delegation.delegate;
+            }
+
+            // Here we perform the requested invocation.
+            Transaction memory transaction = invocation.transaction;
+
+            require(
+                transaction.to == address(this),
+                "DelegatableCore:invalid-invocation-target"
+            );
+
+            // TODO(@kames): Can we bubble up the error message from the enforcer? Why not? Optimizations?
+            success = _execute(
+                transaction.to,
+                transaction.data,
+                transaction.gasLimit,
+                intendedSender
+            );
+            require(success, "DelegatableCore::execution-failed");
+        }
+    }
+
+    function _msgSender() internal view virtual returns (address sender) {
+        if (msg.sender == address(this)) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            assembly {
+                sender := and(
+                    mload(add(array, index)),
+                    0xffffffffffffffffffffffffffffffffffffffff
+                )
+            }
+        } else {
+            sender = msg.sender;
+        }
+        return sender;
+    }
+}

--- a/contracts/DelegatableRelayCore.sol
+++ b/contracts/DelegatableRelayCore.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import {EIP712Decoder, EIP712DOMAIN_TYPEHASH} from "./TypesAndDecoders.sol";
 import {Delegation, Invocation, Invocations, SignedInvocation, SignedDelegation, Transaction, ReplayProtection, CaveatEnforcer} from "./CaveatEnforcer.sol";
 
-abstract contract DelegatableCore is EIP712Decoder {
+abstract contract DelegatableRelayCore is EIP712Decoder {
     /// @notice Account delegation nonce manager
     mapping(address => mapping(uint256 => uint256)) internal multiNonce;
 
@@ -119,11 +119,6 @@ abstract contract DelegatableCore is EIP712Decoder {
 
             // Here we perform the requested invocation.
             Transaction memory transaction = invocation.transaction;
-
-            require(
-                transaction.to == address(this),
-                "DelegatableCore:invalid-invocation-target"
-            );
 
             // TODO(@kames): Can we bubble up the error message from the enforcer? Why not? Optimizations?
             success = _execute(

--- a/contracts/mock/MockRelayedDelegatable.sol
+++ b/contracts/mock/MockRelayedDelegatable.sol
@@ -1,0 +1,40 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../Delegatable.sol";
+
+contract MockRelayedDelegatable is Ownable {
+    string public purpose = "What is my purpose?";
+    address public trustedRelay;
+
+    constructor(address _trustedRelay) {
+        trustedRelay = _trustedRelay;
+    }
+
+    function setPurpose(string memory purpose_) public onlyOwner {
+        purpose = purpose_;
+    }
+
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(Context)
+        returns (address sender)
+    {
+        if (msg.sender == trustedRelay) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            assembly {
+                sender := and(
+                    mload(add(array, index)),
+                    0xffffffffffffffffffffffffffffffffffffffff
+                )
+            }
+        } else {
+            sender = msg.sender;
+        }
+        return sender;
+    }
+}

--- a/test/DelegatableRelay.test.ts
+++ b/test/DelegatableRelay.test.ts
@@ -1,0 +1,203 @@
+import { ethers } from "hardhat";
+import { Contract, ContractFactory, utils, Wallet } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+// @ts-ignore
+import { generateUtil } from "eth-delegatable-utils";
+import { getPrivateKeys } from "../utils/getPrivateKeys";
+import { expect } from "chai";
+import { Provider } from "@ethersproject/providers";
+import { generateDelegation } from "./utils";
+const { getSigners } = ethers;
+
+describe("DelegatableRelay", () => {
+  const CONTACT_NAME = "DelegatableRelay";
+  let CONTRACT_INFO: any;
+  let delegatableUtils: any;
+  let signer0: SignerWithAddress;
+  let wallet0: Wallet;
+  let wallet1: Wallet;
+  let pk0: string;
+  let pk1: string;
+
+  let DelegatableRelay: Contract;
+  let DelegatableRelayFactory: ContractFactory;
+  let AllowedMethodsEnforcer: Contract;
+  let AllowedMethodsEnforcerFactory: ContractFactory;
+  let Mock: Contract;
+  let MockFactory: ContractFactory;
+
+  before(async () => {
+    [signer0] = await getSigners();
+    [wallet0, wallet1] = getPrivateKeys(
+      signer0.provider as unknown as Provider
+    );
+
+    DelegatableRelayFactory = await ethers.getContractFactory(CONTACT_NAME);
+    DelegatableRelay = await DelegatableRelayFactory.deploy();
+
+    MockFactory = await ethers.getContractFactory("MockRelayedDelegatable");
+    AllowedMethodsEnforcerFactory = await ethers.getContractFactory(
+      "AllowedMethodsEnforcer"
+    );
+    pk0 = wallet0._signingKey().privateKey;
+    pk1 = wallet1._signingKey().privateKey;
+  });
+
+  beforeEach(async () => {
+    Mock = await MockFactory.connect(wallet0).deploy(
+     DelegatableRelay.address 
+    );
+    AllowedMethodsEnforcer = await AllowedMethodsEnforcerFactory.connect(
+      wallet0
+    ).deploy();
+
+    CONTRACT_INFO = {
+      chainId: DelegatableRelay.deployTransaction.chainId,
+      verifyingContract: DelegatableRelay.address,
+      name: CONTACT_NAME,
+    };
+    delegatableUtils = generateUtil(CONTRACT_INFO);
+  });
+
+  it("READ verifyDelegationSignature(SignedDelegation memory signedDelegation)`", async () => {
+    const _delegation = generateDelegation(
+      CONTACT_NAME,
+      DelegatableRelay,
+      pk0,
+      wallet1.address
+    );
+    expect(await DelegatableRelay.verifyDelegationSignature(_delegation)).to.eq(
+      wallet0.address
+    );
+  });
+
+  it("READ verifyInvocationSignature(SignedInvocation memory signedInvocation)", async () => {
+    const _delegation = generateDelegation(
+      CONTACT_NAME,
+      DelegatableRelay,
+      pk0,
+      wallet1.address
+    );
+    const INVOCATION_MESSAGE = {
+      replayProtection: {
+        nonce: "0x01",
+        queue: "0x00",
+      },
+      batch: [
+        {
+          authority: [_delegation],
+          transaction: {
+            to: Mock.address,
+            gasLimit: "21000000000000",
+            data: (
+              await Mock.populateTransaction.setPurpose("To delegate!")
+            ).data,
+          },
+        },
+      ],
+    };
+    const invocation = delegatableUtils.signInvocation(INVOCATION_MESSAGE, pk0);
+    expect(await DelegatableRelay.verifyInvocationSignature(invocation)).to.eq(
+      wallet0.address
+    );
+  });
+
+  describe("contractInvoke(Invocation[] calldata batch)", () => {
+    it("should SUCCEED to EXECUTE batched Invocations", async () => {
+      expect(await Mock.purpose()).to.eq("What is my purpose?");
+      const _delegation = generateDelegation(
+        CONTACT_NAME,
+        DelegatableRelay,
+        pk0,
+        wallet1.address
+      );
+      await DelegatableRelay.contractInvoke([
+        {
+          authority: [_delegation],
+          transaction: {
+            to: Mock.address,
+            gasLimit: "21000000000000",
+            data: (
+              await Mock.populateTransaction.setPurpose("To delegate!")
+            ).data,
+          },
+        },
+      ]);
+      expect(await Mock.purpose()).to.eq("To delegate!");
+    });
+  });
+
+  describe("invoke(SignedInvocation[] calldata signedInvocations)", () => {
+    it("should SUCCEED to EXECUTE a single Invocation from an unsigned authority", async () => {
+      expect(await Mock.purpose()).to.eq("What is my purpose?");
+      const INVOCATION_MESSAGE = {
+        replayProtection: {
+          nonce: "0x01",
+          queue: "0x00",
+        },
+        batch: [
+          {
+            authority: [],
+            transaction: {
+              to: Mock.address,
+              gasLimit: "21000000000000",
+              data: (
+                await Mock.populateTransaction.setPurpose("To delegate!")
+              ).data,
+            },
+          },
+        ],
+      };
+      const invocation = delegatableUtils.signInvocation(
+        INVOCATION_MESSAGE,
+        pk0
+      );
+      await DelegatableRelay.invoke([
+        {
+          signature: invocation.signature,
+          invocations: invocation.invocations,
+        },
+      ]);
+      expect(await Mock.purpose()).to.eq("To delegate!");
+    });
+
+    it("should SUCCEED to EXECUTE batched SignedInvocations", async () => {
+      expect(await Mock.purpose()).to.eq("What is my purpose?");
+      const _delegation = generateDelegation(
+        CONTACT_NAME,
+        DelegatableRelay,
+        pk0,
+        wallet1.address
+      );
+      const INVOCATION_MESSAGE = {
+        replayProtection: {
+          nonce: "0x02",
+          queue: "0x00",
+        },
+        batch: [
+          {
+            authority: [_delegation],
+            transaction: {
+              to: Mock.address,
+              gasLimit: "21000000000000",
+              data: (
+                await Mock.populateTransaction.setPurpose("To delegate!")
+              ).data,
+            },
+          },
+        ],
+      };
+      const invocation = delegatableUtils.signInvocation(
+        INVOCATION_MESSAGE,
+        pk0
+      );
+      await DelegatableRelay.invoke([
+        {
+          signature: invocation.signature,
+          invocations: invocation.invocations,
+        },
+      ]);
+      expect(await Mock.purpose()).to.eq("To delegate!");
+    });
+  });
+});


### PR DESCRIPTION
[Per these notes](https://roamresearch.com/#/app/capabul/page/nWDVswjuB)
[Published on mainnet here](https://etherscan.io/address/0x9a345087984D5372C0b51072e792C0A744fdc9c7#code)

- Somehow realized a bit slow: Per the [[Generalized MetaTransaction]] pattern, each contract does not need to deploy its own signature verification code!
    - This means contracts that want to be delegatable can do so much cheaper (per deploy) with an increased cost per transaction.
        - Just add the special `_msgSender()` and use it everywhere for authority checks:
- Changes needed
    - Removing the `tx.to == address(this)` [check](https://github.com/delegatable/delegatable-sol/blob/d12016f532887fb3d7df1f51ff50977d5cb652f7/contracts/DelegatableCore.sol#L123-L126).
    - Have to make decision about the [[[[EIP 712: signTypedData]] domain hash]]. Do one of:
        - Use the domain hash of the relevant contract: compute the domain hash for the recipient from the relay
            - increased gas cost for every domain hash generation
        - Use the domain hash of the relay
            - Less obvious to the signing user what contract this signature pertains to
            - Cheaper gas cost
            - Much simpler change to make (basically just Removing the `tx.to == address(this)` [check](https://github.com/delegatable/delegatable-sol/blob/d12016f532887fb3d7df1f51ff50977d5cb652f7/contracts/DelegatableCore.sol#L123-L126).)
            - A naïve delegation will grant for ALL trusting contracts, making this a LOT like [[[[EIP]] 3074: Delegated Invocation Contracts]], along with its security fears: One signature could grant all your account's permissions for many contracts.
                - Should we add a target contract to the delegation object, or just try to normalize including a caveat for the recipient contract?
                - Could be seen as a feature? Easier to grant multiple permissions with one signature?
                    - Since these signatures are free to issue, the benefits of issuing fewer are small.
    - The JS libraries will need some changes
        - Can't assume that the verifying contract is always also `tx.to`.
