### PR TITLE
Add Revocation caveat enforcer

### DIFF
--- a/contracts/enforcers/RevocationEnforcer.sol
+++ b/contracts/enforcers/RevocationEnforcer.sol
@@ -20,10 +20,14 @@ contract RevocationEnforcer is
         return true;
     }
 
-    function revokeDelegation(SignedDelegation calldata signedDelegation, bytes32 domainHash)
-        public
-    {
-        address signer = verifyExternalDelegationSignature(signedDelegation, domainHash);
+    function revokeDelegation(
+        SignedDelegation calldata signedDelegation,
+        bytes32 domainHash
+    ) public {
+        address signer = verifyExternalDelegationSignature(
+            signedDelegation,
+            domainHash
+        );
         address sender = _msgSender();
         console.log("Sender is ", sender);
         console.log("signer is ", signer);
@@ -35,14 +39,15 @@ contract RevocationEnforcer is
         isRevoked[delegationHash] = true;
     }
 
-    function verifyExternalDelegationSignature(SignedDelegation memory signedDelegation, bytes32 domainHash)
-        public
-        view
-        virtual
-        returns (address)
-    {
+    function verifyExternalDelegationSignature(
+        SignedDelegation memory signedDelegation,
+        bytes32 domainHash
+    ) public view virtual returns (address) {
         Delegation memory delegation = signedDelegation.delegation;
-        bytes32 sigHash = getExternalDelegationTypedDataHash(delegation, domainHash);
+        bytes32 sigHash = getExternalDelegationTypedDataHash(
+            delegation,
+            domainHash
+        );
         address recoveredSignatureSigner = recover(
             sigHash,
             signedDelegation.signature
@@ -50,11 +55,10 @@ contract RevocationEnforcer is
         return recoveredSignatureSigner;
     }
 
-    function getExternalDelegationTypedDataHash(Delegation memory delegation, bytes32 domainHash)
-        public
-        pure
-        returns (bytes32)
-    {
+    function getExternalDelegationTypedDataHash(
+        Delegation memory delegation,
+        bytes32 domainHash
+    ) public pure returns (bytes32) {
         bytes32 digest = keccak256(
             abi.encodePacked(
                 "\x19\x01",
@@ -64,7 +68,6 @@ contract RevocationEnforcer is
         );
         return digest;
     }
-
 
     /**
      * This is boilerplate that must be added to any Delegatable contract if it also inherits

--- a/contracts/enforcers/RevocationEnforcer.sol
+++ b/contracts/enforcers/RevocationEnforcer.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.8.15;
+//SPDX-License-Identifier: MIT
+
+import "../CaveatEnforcer.sol";
+import "../Delegatable.sol";
+
+contract RevocationEnforcer is CaveatEnforcer, Delegatable("RevocationEnforcer", "1") {
+
+  mapping(bytes32 => bool) isRevoked;
+  function enforceCaveat(
+    bytes calldata _terms,
+    Transaction calldata _transaction,
+    bytes32 delegationHash
+  ) public view override returns (bool) {
+    require(!isRevoked[delegationHash], "Delegation has been revoked");
+    return true;
+  }
+
+  function revokeDelegation(SignedDelegation calldata signedDelegation) public {
+    address signer = verifyDelegationSignature(signedDelegation);
+    address sender = _msgSender();
+    require(signer == sender, "Only the signer can revoke a delegation");
+    bytes32 delegationHash = GET_SIGNEDDELEGATION_PACKETHASH(signedDelegation);
+    isRevoked[delegationHash] = true;
+  }
+
+  /**
+   * This is boilerplate that must be added to any Delegatable contract if it also inherits
+   * from another class that also implements _msgSender().
+   */
+  function _msgSender () internal view override returns (address sender) {
+    if(msg.sender == address(this)) {
+      bytes memory array = msg.data;
+      uint256 index = msg.data.length;
+      assembly {
+        // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
+        sender := and(mload(add(array, index)), 0xffffffffffffffffffffffffffffffffffffffff)
+      }
+    } else {
+      sender = msg.sender;
+    }
+    return sender;
+  }
+}

--- a/contracts/enforcers/RevocationEnforcer.sol
+++ b/contracts/enforcers/RevocationEnforcer.sol
@@ -3,42 +3,87 @@ pragma solidity ^0.8.15;
 
 import "../CaveatEnforcer.sol";
 import "../Delegatable.sol";
+import "hardhat/console.sol";
 
-contract RevocationEnforcer is CaveatEnforcer, Delegatable("RevocationEnforcer", "1") {
+contract RevocationEnforcer is
+    CaveatEnforcer,
+    Delegatable("RevocationEnforcer", "1")
+{
+    mapping(bytes32 => bool) isRevoked;
 
-  mapping(bytes32 => bool) isRevoked;
-  function enforceCaveat(
-    bytes calldata _terms,
-    Transaction calldata _transaction,
-    bytes32 delegationHash
-  ) public view override returns (bool) {
-    require(!isRevoked[delegationHash], "Delegation has been revoked");
-    return true;
-  }
-
-  function revokeDelegation(SignedDelegation calldata signedDelegation) public {
-    address signer = verifyDelegationSignature(signedDelegation);
-    address sender = _msgSender();
-    require(signer == sender, "Only the signer can revoke a delegation");
-    bytes32 delegationHash = GET_SIGNEDDELEGATION_PACKETHASH(signedDelegation);
-    isRevoked[delegationHash] = true;
-  }
-
-  /**
-   * This is boilerplate that must be added to any Delegatable contract if it also inherits
-   * from another class that also implements _msgSender().
-   */
-  function _msgSender () internal view override returns (address sender) {
-    if(msg.sender == address(this)) {
-      bytes memory array = msg.data;
-      uint256 index = msg.data.length;
-      assembly {
-        // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
-        sender := and(mload(add(array, index)), 0xffffffffffffffffffffffffffffffffffffffff)
-      }
-    } else {
-      sender = msg.sender;
+    function enforceCaveat(
+        bytes calldata _terms,
+        Transaction calldata _transaction,
+        bytes32 delegationHash
+    ) public view override returns (bool) {
+        require(!isRevoked[delegationHash], "RevocationEnforcer:revoked");
+        return true;
     }
-    return sender;
-  }
+
+    function revokeDelegation(SignedDelegation calldata signedDelegation, bytes32 domainHash)
+        public
+    {
+        address signer = verifyExternalDelegationSignature(signedDelegation, domainHash);
+        address sender = _msgSender();
+        console.log("Sender is ", sender);
+        console.log("signer is ", signer);
+        console.log("msg sender is ", msg.sender);
+        require(signer == sender, "RevocationEnforcer:invalid-revoker");
+        bytes32 delegationHash = GET_SIGNEDDELEGATION_PACKETHASH(
+            signedDelegation
+        );
+        isRevoked[delegationHash] = true;
+    }
+
+    function verifyExternalDelegationSignature(SignedDelegation memory signedDelegation, bytes32 domainHash)
+        public
+        view
+        virtual
+        returns (address)
+    {
+        Delegation memory delegation = signedDelegation.delegation;
+        bytes32 sigHash = getExternalDelegationTypedDataHash(delegation, domainHash);
+        address recoveredSignatureSigner = recover(
+            sigHash,
+            signedDelegation.signature
+        );
+        return recoveredSignatureSigner;
+    }
+
+    function getExternalDelegationTypedDataHash(Delegation memory delegation, bytes32 domainHash)
+        public
+        pure
+        returns (bytes32)
+    {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainHash,
+                GET_DELEGATION_PACKETHASH(delegation)
+            )
+        );
+        return digest;
+    }
+
+
+    /**
+     * This is boilerplate that must be added to any Delegatable contract if it also inherits
+     * from another class that also implements _msgSender().
+     */
+    function _msgSender() internal view override returns (address sender) {
+        if (msg.sender == address(this)) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            assembly {
+                // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
+                sender := and(
+                    mload(add(array, index)),
+                    0xffffffffffffffffffffffffffffffffffffffff
+                )
+            }
+        } else {
+            sender = msg.sender;
+        }
+        return sender;
+    }
 }

--- a/test/enforcers/RevocationEnforcer.test.ts
+++ b/test/enforcers/RevocationEnforcer.test.ts
@@ -1,0 +1,167 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Provider } from "@ethersproject/providers";
+import { BigNumber, Contract, ContractFactory, Wallet } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+// @ts-ignore
+import { generateUtil } from "eth-delegatable-utils";
+import { getPrivateKeys } from "../../utils/getPrivateKeys";
+import { generateDelegation } from "../utils";
+
+const { getSigners } = ethers;
+
+describe("RevocationEnforcer", () => {
+  const CONTRACT_NAME = "ERC20Delegatable";
+  let CONTRACT_INFO: any;
+  let delegatableUtils: any;
+  let signer0: SignerWithAddress;
+  let wallet0: Wallet;
+  let wallet1: Wallet;
+  let pk0: string;
+  let pk1: string;
+
+  // Smart Contracts
+  let RevocationEnforcer: Contract;
+  let RevocationEnforcerFactory: ContractFactory;
+  let ERC20Delegatable: Contract;
+  let ERC20DelegatableFactory: ContractFactory;
+
+  before(async () => {
+    [signer0] = await getSigners();
+    [wallet0, wallet1] = getPrivateKeys(
+      signer0.provider as unknown as Provider
+    );
+    ERC20DelegatableFactory = await ethers.getContractFactory(
+      "ERC20Delegatable"
+    );
+    RevocationEnforcerFactory = await ethers.getContractFactory(
+      "RevocationEnforcer"
+    );
+    pk0 = wallet0._signingKey().privateKey;
+    pk1 = wallet1._signingKey().privateKey;
+  });
+
+  beforeEach(async () => {
+    ERC20Delegatable = await ERC20DelegatableFactory.connect(wallet0).deploy(
+      CONTRACT_NAME,
+      "TRUST",
+      ethers.utils.parseEther("1")
+    );
+    RevocationEnforcer = await RevocationEnforcerFactory.connect(
+      wallet0
+    ).deploy();
+
+    CONTRACT_INFO = {
+      chainId: ERC20Delegatable.deployTransaction.chainId,
+      verifyingContract: ERC20Delegatable.address,
+      name: CONTRACT_NAME,
+    };
+    delegatableUtils = generateUtil(CONTRACT_INFO);
+  });
+
+  it("should SUCCEED to INVOKE method APPROVED for execution", async () => {
+    console.log("Wallet 0", wallet0.address);
+    console.log("Wallet 1", wallet1.address);
+    expect(await ERC20Delegatable.balanceOf(wallet0.address)).to.eq(
+      ethers.utils.parseEther("1")
+    );
+    const _delegation = generateDelegation(
+      CONTRACT_NAME,
+      ERC20Delegatable,
+      pk0,
+      wallet1.address,
+      [
+        {
+          enforcer: RevocationEnforcer.address,
+          terms: "0x00",
+        },
+      ]
+    );
+    const INVOCATION_MESSAGE = {
+      replayProtection: {
+        nonce: "0x01",
+        queue: "0x00",
+      },
+      batch: [
+        {
+          authority: [_delegation],
+          transaction: {
+            to: ERC20Delegatable.address,
+            gasLimit: "210000000000000000",
+            data: (
+              await ERC20Delegatable.populateTransaction.transfer(
+                wallet1.address,
+                ethers.utils.parseEther("0.5")
+              )
+            ).data,
+          },
+        },
+      ],
+    };
+    const invocation = delegatableUtils.signInvocation(INVOCATION_MESSAGE, pk1);
+    await ERC20Delegatable.invoke([
+      {
+        signature: invocation.signature,
+        invocations: invocation.invocations,
+      },
+    ]);
+    expect(await ERC20Delegatable.balanceOf(wallet0.address)).to.eq(
+      ethers.utils.parseEther("0.5")
+    );
+  });
+
+  it("should FAIL to INVOKE method AFTER REVOCATION", async () => {
+    expect(await ERC20Delegatable.balanceOf(wallet0.address)).to.eq(
+      ethers.utils.parseEther("1")
+    );
+    const _delegation = generateDelegation(
+      CONTRACT_NAME,
+      ERC20Delegatable,
+      pk0,
+      wallet1.address,
+      [
+        {
+          enforcer: RevocationEnforcer.address,
+          terms: "0x00",
+        },
+      ]
+    );
+    console.log(JSON.stringify(_delegation));
+
+    await RevocationEnforcer.connect(wallet0).revokeDelegation(
+      _delegation,
+      domainHash
+    );
+
+    const INVOCATION_MESSAGE = {
+      replayProtection: {
+        nonce: "0x01",
+        queue: "0x00",
+      },
+      batch: [
+        {
+          authority: [_delegation],
+          transaction: {
+            to: ERC20Delegatable.address,
+            gasLimit: "210000000000000000",
+            data: (
+              await ERC20Delegatable.populateTransaction.transfer(
+                wallet1.address,
+                ethers.utils.parseEther("0.5")
+              )
+            ).data,
+          },
+        },
+      ],
+    };
+    const invocation = delegatableUtils.signInvocation(INVOCATION_MESSAGE, pk1);
+    await expect(
+      ERC20Delegatable.invoke([
+        {
+          signature: invocation.signature,
+          invocations: invocation.invocations,
+        },
+      ])
+    ).to.be.revertedWith("LimitedCallsEnforcer:limit-exceeded");
+  });
+});

--- a/test/enforcers/RevocationEnforcer.test.ts
+++ b/test/enforcers/RevocationEnforcer.test.ts
@@ -60,8 +60,6 @@ describe("RevocationEnforcer", () => {
   });
 
   it("should SUCCEED to INVOKE method APPROVED for execution", async () => {
-    console.log("Wallet 0", wallet0.address);
-    console.log("Wallet 1", wallet1.address);
     expect(await ERC20Delegatable.balanceOf(wallet0.address)).to.eq(
       ethers.utils.parseEther("1")
     );
@@ -126,7 +124,8 @@ describe("RevocationEnforcer", () => {
         },
       ]
     );
-    console.log(JSON.stringify(_delegation));
+
+    const domainHash = await RevocationEnforcer.getEIP712DomainHash(CONTRACT_NAME, "1", CONTRACT_INFO.chainId, ERC20Delegatable.address);
 
     await RevocationEnforcer.connect(wallet0).revokeDelegation(
       _delegation,
@@ -162,6 +161,6 @@ describe("RevocationEnforcer", () => {
           invocations: invocation.invocations,
         },
       ])
-    ).to.be.revertedWith("LimitedCallsEnforcer:limit-exceeded");
+    ).to.be.revertedWith("RevocationEnforcer:revoked");
   });
 });


### PR DESCRIPTION
I suspect @kamescg didn't migrate this from the old `-eth` repo because that caveat actually didn't work right!

It was opinionated and assumed the domainHash (and all contract info) of the relevant contract.

Now the revocation method requires the user to include the `domainHash` of the contract to revoke for. Should be safe because the signature would not recover to them unless they had signed the blob (a chosen data attack seems very unlikely and at worst could disrupt someone else's delegation, but could not escalate any privileges).

Example in the now passing test.