### PR TITLE
Explicitly set Invoke Return Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # KEEP SAFE
 .env
+.envrc
 
 # Development
 abis

--- a/contracts/Delegatable.sol
+++ b/contracts/Delegatable.sol
@@ -136,7 +136,10 @@ abstract contract Delegatable is IDelegatable, DelegatableCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(
+                signedInvocation.invocations.batch,
+                invocationSigner
+            );
         }
     }
 

--- a/contracts/Delegatable.sol
+++ b/contracts/Delegatable.sol
@@ -136,7 +136,7 @@ abstract contract Delegatable is IDelegatable, DelegatableCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
         }
     }
 

--- a/contracts/DelegatableFacet.sol
+++ b/contracts/DelegatableFacet.sol
@@ -151,7 +151,10 @@ contract DelegatableFacet is IDelegatable, DelegatableCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(
+                signedInvocation.invocations.batch,
+                invocationSigner
+            );
         }
     }
 

--- a/contracts/DelegatableFacet.sol
+++ b/contracts/DelegatableFacet.sol
@@ -151,7 +151,7 @@ contract DelegatableFacet is IDelegatable, DelegatableCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
         }
     }
 

--- a/contracts/DelegatableRelay.sol
+++ b/contracts/DelegatableRelay.sol
@@ -134,7 +134,10 @@ contract DelegatableRelay is IDelegatable, DelegatableRelayCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(
+                signedInvocation.invocations.batch,
+                invocationSigner
+            );
         }
     }
 

--- a/contracts/DelegatableRelay.sol
+++ b/contracts/DelegatableRelay.sol
@@ -134,7 +134,7 @@ contract DelegatableRelay is IDelegatable, DelegatableRelayCore {
                 invocationSigner,
                 signedInvocations[i].invocations.replayProtection
             );
-            _invoke(signedInvocation.invocations.batch, invocationSigner);
+            success = _invoke(signedInvocation.invocations.batch, invocationSigner);
         }
     }
 


### PR DESCRIPTION
Related to #7 

Problem: Compile warning

```
warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/delegatable-sol/contracts/Delegatable.sol:128:18:
    |
128 |         returns (bool success)
    |                  ^^^^^^^^^^^^
```

Solution: Explicitly set the `success` return variable of all external `invoke` functions.

Change increases gas consumption for the `invoke` function by 3

![del-diff](https://user-images.githubusercontent.com/81343914/223896383-a830c7e3-c6ee-48fc-8d47-2e5c2a60ab6f.png)

