### PR TITLE
test: assert root delegation caveat enforcement

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,6 +3,13 @@ import { generateUtil } from "eth-delegatable-utils";
 const BASE_AUTH =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
+export function prepend0x(hex: string): string {
+  if (hex.toLowerCase().slice(0, 2) === "0x") {
+    return hex;
+  }
+  return "0x" + hex;
+}
+
 export function generateDelegation(
   name: any,
   contract: any,


### PR DESCRIPTION
## Summary

Assert chained delegations can not be used to transfer more ERC20 tokens than the root delegation permits. Tests a scenario where an initial delegation allows some amount X of ERC20 transfer which is then re-delegated allowing some amount >X and asserts that some amount >X can not be transferred.
Impacts test files only.

## Motivation

- ERC20 Allowance caveats are enforced at the delegation level using a mapping from a delegation hash, so this change is meant to check the integrity of the root delegation's caveat enforcement.
